### PR TITLE
Add intrepter and absolute path to run_scenario

### DIFF
--- a/12e-t2-s0/run_scenario.sh
+++ b/12e-t2-s0/run_scenario.sh
@@ -1,4 +1,6 @@
-source ../scenario_functions.sh
+#!/usr/bin/env bash
+
+source /proj/edgect/scenarios/scenario_functions.sh
 
 # Available modules: general_viz rtp iperf
 MODULES="general_viz iperf"

--- a/12e-t2-s1/run_scenario.sh
+++ b/12e-t2-s1/run_scenario.sh
@@ -1,3 +1,5 @@
+#!/usr/bin/env bash
+
 source /proj/edgect/scenarios/scenario_functions.sh
 
 # Available traffic modules: rtp iperf targeted_loss simple_reorder

--- a/2e-t0-s1/run_scenario.sh
+++ b/2e-t0-s1/run_scenario.sh
@@ -1,3 +1,5 @@
+#!/usr/bin/env bash
+
 source /proj/edgect/scenarios/scenario_functions.sh
 
 # Available modules: rtp iperf targeted_loss simple_reorder tcpdump1

--- a/6e-t1-s1/run_scenario.sh
+++ b/6e-t1-s1/run_scenario.sh
@@ -1,4 +1,6 @@
-source ../scenario_functions.sh
+#!/usr/bin/env bash
+
+source /proj/edgect/scenarios/scenario_functions.sh
 
 MODULES="general_viz click rtp"
 echo "Starting: ${MODULES}"


### PR DESCRIPTION
This commit adds the intrepter to each run_scenario shell script.  As the wiki
points out that the 'sudo ./run_scenario.sh' should be used.

This commit also standardizes the absolute path for scenario_functions.sh
located in /proj/edgect/scenarios/ rather than having both absolute and relative
paths.  This will allow users to copy the run_scenario.sh script without having
to manually point to scenario_functions.